### PR TITLE
Fix code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/resources/js/services/excanvas.js
+++ b/resources/js/services/excanvas.js
@@ -846,6 +846,15 @@ if (!document.createElement('canvas').getContext) {
       const w2 = sw / 2;
       const h2 = sh / 2;
 
+      function escapeHtml(unsafe) {
+        return unsafe
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#039;");
+      }
+
       const vmlStr = [];
 
       const W = 10;
@@ -928,7 +937,7 @@ if (!document.createElement('canvas').getContext) {
       vmlStr.push(
         ' ">',
         '<g_vml_:image src="',
-        image.src,
+        escapeHtml(image.src),
         '"',
         ' style="width:',
         Z * dw,


### PR DESCRIPTION
Fixes [https://github.com/jeremykenedy/laravel-spa/security/code-scanning/3](https://github.com/jeremykenedy/laravel-spa/security/code-scanning/3)

To fix the problem, we need to ensure that the `image.src` value is properly escaped before being inserted into the DOM. This can be achieved by using a function that escapes HTML special characters. We will create a utility function to escape the `image.src` value and use it before inserting the string into the DOM.

1. Create a utility function to escape HTML special characters.
2. Use this function to escape the `image.src` value before adding it to the `vmlStr` array.
3. Ensure that the escaped value is used in the `vmlStr` array before calling `insertAdjacentHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
